### PR TITLE
Fix crash when an option has an empty string value

### DIFF
--- a/src/select-virtualized/shared-helpers/getters.js
+++ b/src/select-virtualized/shared-helpers/getters.js
@@ -11,7 +11,7 @@ export const getListHeight = ({
 export const getScrollIndex = ({ children, selected, valueGetter }) => {
   if (children && selected && valueGetter)
     return children.findIndex(
-      (child) => (valueGetter(child) || valueGetter(child.props.data)) === valueGetter(selected),
+      (child) => ((valueGetter(child) !== undefined) || valueGetter(child.props.data)) === valueGetter(selected),
     );
   return undefined;
 };


### PR DESCRIPTION
Hi!

We experienced a crash when our option list has an element with the value of "".
You can reproduce it on the basic storybook demo if you change data.js like this:
```
export const optionsDefault = [
  {value: "", label: "", lang: random.language()},
  ...new Array(20).fill(null).map(() => ({
  value: random.guid(),
  label: `${random.maleFirstName()} - ${random.email('test.com.au')}`,
  lang: random.language(),
}))];
```

Now select a value and try to open up the dropdown again.

The crash is inside `getScrollIndex` (*getters.js*), called by *FlatVirtualizedList* with the list of options as `children`. `valueGetter` does find the value, but it is `""` which is falsy, so it moves on to the right hand side of the or, where accessing `child.props.data` throws for obvious reasons.

**I prepared a small fix** for it where I check that valueGetter actually returned undefined. Alternatively we could check for the existence of `props` first. 