### PR TITLE
Use ranges in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,10 +91,10 @@
     }
   },
   "peerDependencies": {
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
-    "react-select": "5.1.0",
-    "react-virtualized": "9.22.3"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-select": "^5.1.0",
+    "react-virtualized": "^9.22.3"
   },
   "dependencies": {
     "lodash.debounce": "4.0.8",


### PR DESCRIPTION
Peer dependencies should use ranges, or else it will be impossible to properly update them all.


```

❯ npm install react-select-virtualized@latest
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: @pixiebrix/extension@1.4.10-alpha.1
npm ERR! Found: react-select@5.2.1
npm ERR! node_modules/react-select
npm ERR!   react-select@"^5.2.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react-select@"5.1.0" from react-select-virtualized@4.2.0
npm ERR! node_modules/react-select-virtualized
npm ERR!   react-select-virtualized@"4.2.0" from the root project

```